### PR TITLE
Add Documenter.jl + Literate.jl documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+  statuses: write
+jobs:
+  build:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
+        with:
+          version: '1'
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38
+      - name: Install dependencies
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@
 *.jl.cov
 *.jl.mem
 /docs/build/
+/docs/site/
+docs/Manifest.toml
+# files generated automatically by Literate.jl
+docs/src/literate/*.md
 .vscode
 test/LocalPreferences.toml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # HMMER.jl
 
+[![Documentation (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/HMMER.jl/stable)
+[![Documentation (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/HMMER.jl/dev)
+
 A thin Julia wrapper of [hmmer](http://hmmer.org). Functions have the same name as the HMMER programs (and Easel miniapps). Keyword arguments are named consistently with the command line arguments of the respective programs. The package creates temporary files for output and returns the path.
 
 ## Installation

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+HMMER = "59c5aa83-900c-4c4d-b6cc-c9bbbf32a260"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+
+[compat]
+Documenter = "1"
+Literate = "2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,34 @@
+import Documenter
+import Literate
+import HMMER
+
+# Run Literate.jl over the tutorial sources, generating Markdown files next to
+# them. The generated `.md` files are git-ignored (see `.gitignore`).
+const literate_dir = joinpath(@__DIR__, "src", "literate")
+for file in readdir(literate_dir; join = true)
+    if endswith(file, ".jl")
+        Literate.markdown(file, literate_dir; documenter = true)
+    end
+end
+
+Documenter.makedocs(
+    modules = [HMMER],
+    sitename = "HMMER.jl",
+    authors = "Jorge Fernandez-de-Cossio-Diaz",
+    repo = Documenter.Remotes.GitHub("cossio", "HMMER.jl"),
+    pages = [
+        "Home" => "index.md",
+        "Tutorial" => "literate/tutorial.md",
+        "Reference" => "reference.md",
+    ],
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://cossio.github.io/HMMER.jl/stable/",
+    ),
+)
+
+Documenter.deploydocs(
+    repo = "github.com/cossio/HMMER.jl.git",
+    devbranch = "main",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,28 @@
+# HMMER.jl
+
+A thin Julia wrapper of [HMMER](http://hmmer.org). Functions have the same name
+as the HMMER programs (and Easel miniapps), and keyword arguments are named
+consistently with the command-line arguments of the respective programs. Each
+function creates temporary files for its output and returns a named tuple with
+the spawned process, the captured `stdout`/`stderr`, and the output paths.
+
+## Installation
+
+This package is registered. Install it with:
+
+```julia
+import Pkg
+Pkg.add("HMMER")
+```
+
+## Contents
+
+```@contents
+Pages = ["literate/tutorial.md", "reference.md"]
+Depth = 2
+```
+
+## Related packages
+
+- [Rfam.jl](https://github.com/cossio/Rfam.jl)
+- [Infernal.jl](https://github.com/cossio/Infernal.jl)

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -15,15 +15,7 @@ import HMMER
 # the amino-acid alphabet and `n` sets the model name.
 
 alignment = tempname()
-write(
-    alignment,
-    """
-    # STOCKHOLM 1.0
-    seq1 ACDEFGHIK
-    seq2 ACDEYGHIK
-    //
-    """,
-)
+write(alignment, "# STOCKHOLM 1.0\nseq1 ACDEFGHIK\nseq2 ACDEYGHIK\n//\n")
 
 model = HMMER.hmmbuild(alignment; amino=true, n="toy_profile")
 
@@ -39,15 +31,7 @@ print(read(model.o, String))
 # `hits.tblout`.
 
 seqdb = tempname()
-write(
-    seqdb,
-    """
-    >match
-    ACDEFGHIK
-    >nonmatch
-    TTTTTTTTT
-    """,
-)
+write(seqdb, ">match\nACDEFGHIK\n>nonmatch\nTTTTTTTTT\n")
 
 hits = HMMER.hmmsearch(model.hmmout, seqdb)
 
@@ -66,15 +50,7 @@ profile = HMMER.hmmfetch(model.hmmout, "toy_profile")
 # the profile fetched above and request aligned FASTA output via `outformat`.
 
 seqfile = tempname()
-write(
-    seqfile,
-    """
-    >seq1
-    ACDEFGHIK
-    >seq2
-    ACDEYGHIK
-    """,
-)
+write(seqfile, ">seq1\nACDEFGHIK\n>seq2\nACDEYGHIK\n")
 
 aligned = HMMER.hmmalign(profile.o, seqfile; outformat="afa")
 
@@ -86,15 +62,7 @@ print(read(aligned.o, String))
 # another format. Here we convert a Stockholm alignment to aligned FASTA.
 
 stockholm = tempname()
-write(
-    stockholm,
-    """
-    # STOCKHOLM 1.0
-    seq1 ACDE
-    seq2 AC-E
-    //
-    """,
-)
+write(stockholm, "# STOCKHOLM 1.0\nseq1 ACDE\nseq2 AC-E\n//\n")
 
 fasta = HMMER.esl_reformat("afa", stockholm)
 

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -1,0 +1,101 @@
+# # Tutorial
+#
+# This tutorial shows how to use `HMMER.jl` to build a profile HMM, search a
+# sequence database, fetch a profile, align sequences, and reformat alignments.
+# Every function wraps the corresponding HMMER program (or Easel miniapp) and
+# returns a named tuple containing the spawned `process`, the captured
+# `stdout`/`stderr`, and the paths of the generated output files.
+
+import HMMER
+
+# ## Build a profile
+#
+# We start from a small multiple-sequence alignment in Stockholm format and
+# build a profile HMM with [`HMMER.hmmbuild`](@ref). The `amino` keyword forces
+# the amino-acid alphabet and `n` sets the model name.
+
+alignment = tempname()
+write(
+    alignment,
+    """
+    # STOCKHOLM 1.0
+    seq1 ACDEFGHIK
+    seq2 ACDEYGHIK
+    //
+    """,
+)
+
+model = HMMER.hmmbuild(alignment; amino=true, n="toy_profile")
+
+# The profile HMM is written to `model.hmmout`, and a human-readable summary to
+# `model.o`:
+
+print(read(model.o, String))
+
+# ## Search a sequence database
+#
+# We can now search a FASTA database for matches to the profile with
+# [`HMMER.hmmsearch`](@ref). The per-sequence hit table is written to
+# `hits.tblout`.
+
+seqdb = tempname()
+write(
+    seqdb,
+    """
+    >match
+    ACDEFGHIK
+    >nonmatch
+    TTTTTTTTT
+    """,
+)
+
+hits = HMMER.hmmsearch(model.hmmout, seqdb)
+
+print(read(hits.tblout, String))
+
+# ## Fetch a profile
+#
+# [`HMMER.hmmfetch`](@ref) extracts a single profile (by name) from an HMM
+# database into its own file, available at `profile.o`.
+
+profile = HMMER.hmmfetch(model.hmmout, "toy_profile")
+
+# ## Align sequences to a profile
+#
+# [`HMMER.hmmalign`](@ref) aligns sequences against a profile HMM. Here we use
+# the profile fetched above and request aligned FASTA output via `outformat`.
+
+seqfile = tempname()
+write(
+    seqfile,
+    """
+    >seq1
+    ACDEFGHIK
+    >seq2
+    ACDEYGHIK
+    """,
+)
+
+aligned = HMMER.hmmalign(profile.o, seqfile; outformat="afa")
+
+print(read(aligned.o, String))
+
+# ## Reformat an alignment with Easel
+#
+# Finally, [`HMMER.esl_reformat`](@ref) converts a sequence or alignment file to
+# another format. Here we convert a Stockholm alignment to aligned FASTA.
+
+stockholm = tempname()
+write(
+    stockholm,
+    """
+    # STOCKHOLM 1.0
+    seq1 ACDE
+    seq2 AC-E
+    //
+    """,
+)
+
+fasta = HMMER.esl_reformat("afa", stockholm)
+
+print(read(fasta.o, String))

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,23 @@
+# Reference
+
+```@meta
+CurrentModule = HMMER
+```
+
+This page documents the functions provided by `HMMER.jl`. Each function wraps
+the corresponding HMMER program or Easel miniapp.
+
+## HMMER programs
+
+```@docs
+HMMER.hmmbuild
+HMMER.hmmsearch
+HMMER.hmmfetch
+HMMER.hmmalign
+```
+
+## Easel miniapps
+
+```@docs
+HMMER.esl_reformat
+```


### PR DESCRIPTION
## Summary

Sets up a documentation site for HMMER.jl using **Documenter.jl** and **Literate.jl**, mirroring the workflow used in [Rfam.jl](https://github.com/cossio/Rfam.jl).

## Changes

- `docs/Project.toml` — docs environment (Documenter, Literate, HMMER).
- `docs/make.jl` — runs Literate over `docs/src/literate/*.jl`, then `makedocs` (Home / Tutorial / Reference) and `deploydocs` (`devbranch = "main"`, `push_preview = true`).
- `docs/src/index.md` — landing page.
- `docs/src/reference.md` — `@docs` autodocs for `hmmbuild`, `hmmsearch`, `hmmfetch`, `hmmalign`, `esl_reformat`.
- `docs/src/literate/tutorial.jl` — executed tutorial (build → search → fetch → align → reformat).
- `.github/workflows/Documentation.yml` — builds and deploys docs to GitHub Pages on push to `main`, tags, and PRs.
- `.gitignore` — ignore Literate-generated markdown and docs build artifacts.
- `README.md` — add stable/dev documentation badges.

## Notes

- The tutorial uses the qualified `HMMER.foo(...)` form because the package does not `export` any symbols, so the executed example blocks build correctly.
- Deployment works via `GITHUB_TOKEN` for `main`. `DOCUMENTER_KEY` (for fork-PR previews) must be installed manually — the deploy-keys / Actions-secrets API isn't available to this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3x2MS3GzrkHFH2WzfjBLc)_